### PR TITLE
Feature/inicio sesion externo

### DIFF
--- a/source/backend/Risk.API/Helpers/TokenHelper.cs
+++ b/source/backend/Risk.API/Helpers/TokenHelper.cs
@@ -254,13 +254,20 @@ namespace Risk.API.Helpers
 
                     // Obtenemos datos recibidos del usuario en la respuesta del Graph de facebook
                     string idExterno = jsonRes["id"].ToString();
+                    string nombreCompleto = jsonRes["name"].ToString();
                     string nombre = jsonRes["first_name"].ToString();
                     string apellido = jsonRes["last_name"].ToString();
-                    string direccionCorreo = jsonRes["email"].ToString();
 
-                    MailAddress addr = new MailAddress(direccionCorreo);
-                    string username = addr.User;
-                    string domain = addr.Host;
+                    string direccionCorreo = "";
+                    string username, domain;
+                    if (jsonRes["email"] != null) {
+                        direccionCorreo = jsonRes["email"].ToString();
+                        MailAddress addr = new MailAddress(direccionCorreo);
+                        username = addr.User;
+                        domain = addr.Host;
+                    } else {
+                        username = $"{nombre}_{apellido}".Replace(' ', '_').ToLower();
+                    }
 
                     usuario = new UsuarioExterno
                     {
@@ -275,7 +282,7 @@ namespace Risk.API.Helpers
             }
             catch (Exception e)
             {
-                throw new SecurityTokenValidationException("Token no válido.", e);
+                throw new SecurityTokenValidationException($"Token no válido: {accessToken}.", e);
             }
 
             return usuario;

--- a/source/database/packages/k_autenticacion.pck
+++ b/source/database/packages/k_autenticacion.pck
@@ -405,12 +405,16 @@ CREATE OR REPLACE PACKAGE BODY k_autenticacion IS
         RAISE k_usuario.ex_usuario_existente;
       END IF;
     
-      SELECT i_alias ||
+      l_alias := translate(l_alias,
+                           'áéíóúàèìòùäëïöüñÁÉÍÓÚİÄËÏÖÜÀÈÌÒÙÑ'' ',
+                           'aeiouaeiouaeiounAEIOUYAEIOUAEIOUN__');
+    
+      SELECT l_alias ||
              to_char(MAX(to_number(nvl(regexp_substr(a.alias, '\d+'), '0'))) + 1) alias
         INTO l_alias
         FROM t_usuarios a
-       WHERE (upper(a.alias) = upper(i_alias) OR
-             regexp_like(a.alias, '(' || i_alias || ')\d+', 'i'));
+       WHERE (upper(a.alias) = upper(l_alias) OR
+             regexp_like(a.alias, '(' || l_alias || ')\d+', 'i'));
     END IF;
   
     -- Valida clave

--- a/source/database/packages/k_servicio_aut.pck
+++ b/source/database/packages/k_servicio_aut.pck
@@ -117,11 +117,6 @@ CREATE OR REPLACE PACKAGE BODY k_servicio_aut IS
                                                                          'apellido') IS NOT NULL,
                                     'Debe ingresar apellido');
   
-    k_operacion.p_validar_parametro(l_rsp,
-                                    k_operacion.f_valor_parametro_string(i_parametros,
-                                                                         'direccion_correo') IS NOT NULL,
-                                    'Debe ingresar direccion_correo');
-  
     l_rsp.lugar      := 'Registrando usuario';
     l_dato.contenido := k_autenticacion.f_registrar_usuario(k_operacion.f_valor_parametro_string(i_parametros,
                                                                                                  'usuario'),

--- a/source/database/scripts/operations/servicio/aut/registrar_usuario.sql
+++ b/source/database/scripts/operations/servicio/aut/registrar_usuario.sql
@@ -257,7 +257,7 @@ begin
   l_clob(6) :=q'!S!';
   l_clob(7) :=q'!!';
   l_varchar2(8) :=q'!!';
-  l_clob(9) :=q'!S!';
+  l_clob(9) :=q'!N!';
   l_clob(10) :=q'!!';
   l_clob(11) :=q'!!';
   l_clob(12) :=q'!!';

--- a/source/database/triggers/gb_usuarios.trg
+++ b/source/database/triggers/gb_usuarios.trg
@@ -30,7 +30,18 @@ BEGIN
   IF inserting OR
      (updating AND nvl(:new.alias, 'X') <> nvl(:old.alias, 'X')) THEN
     IF NOT k_usuario.f_validar_alias(:new.alias) THEN
-      raise_application_error(-20000, 'Alias de usuario inválido');
+      IF nvl(:new.origen, k_autenticacion.c_origen_risk) =
+         k_autenticacion.c_origen_risk THEN
+        raise_application_error(-20000,
+                                'Caracteres no permitidos en el Usuario: ' ||
+                                regexp_replace(:new.alias,
+                                               TRIM(translate(k_util.f_valor_parametro('REGEXP_VALIDAR_ALIAS_USUARIO'),
+                                                              '^$',
+                                                              '  ')),
+                                               ''));
+      ELSE
+        raise_application_error(-20000, 'Alias de usuario inválido');
+      END IF;
     END IF;
   END IF;
 


### PR DESCRIPTION
Ajuste para inicio de sesion en facebook de usuarios que no tienen dirección de correo.
Mensaje de caracteres inválidos específicos en validación de alias de usuario.-